### PR TITLE
タグにスペースや中点がある場合に正しく動作しなかったのを修正(adhoc)

### DIFF
--- a/layouts/partials/tag.html
+++ b/layouts/partials/tag.html
@@ -1,5 +1,6 @@
-{{ $tagPage := $.site.GetPage (printf "/tags/%s" $.tag) }}
-<a href="/tags/{{ $.tag }}/">
+{{ $pagePath := (printf "/tags/%s" (replace (replace $.tag " " "-") "・" "")) }}
+{{ $tagPage := $.site.GetPage $pagePath }}
+<a href="/tags/{{ $.tag | urlize }}/">
   {{- safeHTML $.site.Params.tagmark }}
   {{- partialCached "function/page-title" $tagPage $tagPage.RelPermalink -}}
 </a>{{ "" -}}


### PR DESCRIPTION
とりあえずreplaceで対応。